### PR TITLE
LPS 171161

### DIFF
--- a/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectActionLocalServiceImpl.java
+++ b/modules/apps/object/object-service/src/main/java/com/liferay/object/service/impl/ObjectActionLocalServiceImpl.java
@@ -43,6 +43,7 @@ import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.log.Log;
 import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.messaging.DestinationNames;
 import com.liferay.portal.kernel.messaging.MessageBus;
 import com.liferay.portal.kernel.model.SystemEventConstants;
 import com.liferay.portal.kernel.model.User;
@@ -348,6 +349,19 @@ public class ObjectActionLocalServiceImpl
 
 			if (!_messageBus.hasDestination(objectActionTriggerKey)) {
 				throw new ObjectActionTriggerKeyException();
+			}
+
+			if (StringUtil.equals(
+					objectActionTriggerKey,
+					DestinationNames.COMMERCE_ORDER_STATUS) ||
+				StringUtil.equals(
+					objectActionTriggerKey,
+					DestinationNames.COMMERCE_PAYMENT_STATUS) ||
+				StringUtil.equals(
+					objectActionTriggerKey,
+					DestinationNames.COMMERCE_SHIPMENT_STATUS)) {
+
+				return;
 			}
 
 			if (Validator.isNotNull(conditionExpression)) {

--- a/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectAction/tabs/ActionBuilder.tsx
+++ b/modules/apps/object/object-web/src/main/resources/META-INF/resources/js/components/ObjectAction/tabs/ActionBuilder.tsx
@@ -73,6 +73,16 @@ type ObjectsOptionsList = Array<
 	}
 >;
 
+const triggerKeys = [
+	'liferay/commerce_order_status',
+	'liferay/commerce_payment_status',
+	'liferay/commerce_shipment_status',
+	'onAfterAdd',
+	'onAfterAttachmentDownload',
+	'onAfterDelete',
+	'onAfterUpdate',
+];
+
 export default function ActionBuilder({
 	errors,
 	isApproved,
@@ -190,6 +200,10 @@ export default function ActionBuilder({
 
 		return fields;
 	}, [currentObjectDefinitionFields]);
+
+	const showConditionContainer = values.objectActionTriggerKey
+		? triggerKeys.includes(values.objectActionTriggerKey)
+		: true;
 
 	useEffect(() => {
 		if (values.objectActionTriggerKey === 'onAfterDelete') {
@@ -525,57 +539,63 @@ export default function ActionBuilder({
 				</Card>
 			</Card>
 
-			<Card
-				disabled={values.objectActionTriggerKey === 'standalone'}
-				title={Liferay.Language.get('condition')}
-			>
-				<ClayForm.Group>
-					<ClayToggle
-						disabled={
-							values.objectActionTriggerKey === 'standalone'
-						}
-						label={Liferay.Language.get('enable-condition')}
-						name="condition"
-						onToggle={(enable) =>
-							setValues({
-								conditionExpression: enable ? '' : undefined,
-							})
-						}
-						toggled={!(values.conditionExpression === undefined)}
-					/>
-				</ClayForm.Group>
+			{showConditionContainer && (
+				<Card
+					disabled={values.objectActionTriggerKey === 'standalone'}
+					title={Liferay.Language.get('condition')}
+				>
+					<ClayForm.Group>
+						<ClayToggle
+							disabled={
+								values.objectActionTriggerKey === 'standalone'
+							}
+							label={Liferay.Language.get('enable-condition')}
+							name="condition"
+							onToggle={(enable) =>
+								setValues({
+									conditionExpression: enable
+										? ''
+										: undefined,
+								})
+							}
+							toggled={
+								!(values.conditionExpression === undefined)
+							}
+						/>
+					</ClayForm.Group>
 
-				{values.conditionExpression !== undefined && (
-					<ExpressionBuilder
-						error={errors.conditionExpression}
-						feedbackMessage={Liferay.Language.get(
-							'use-expressions-to-create-a-condition'
-						)}
-						label={Liferay.Language.get('expression-builder')}
-						name="conditionExpression"
-						onChange={({target: {value}}) =>
-							setValues({conditionExpression: value})
-						}
-						onOpenModal={() => {
-							const parentWindow = Liferay.Util.getOpener();
+					{values.conditionExpression !== undefined && (
+						<ExpressionBuilder
+							error={errors.conditionExpression}
+							feedbackMessage={Liferay.Language.get(
+								'use-expressions-to-create-a-condition'
+							)}
+							label={Liferay.Language.get('expression-builder')}
+							name="conditionExpression"
+							onChange={({target: {value}}) =>
+								setValues({conditionExpression: value})
+							}
+							onOpenModal={() => {
+								const parentWindow = Liferay.Util.getOpener();
 
-							parentWindow.Liferay.fire(
-								'openExpressionBuilderModal',
-								{
-									onSave: handleSave,
-									required: true,
-									source: values.conditionExpression,
-									validateExpressionURL,
-								}
-							);
-						}}
-						placeholder={Liferay.Language.get(
-							'create-an-expression'
-						)}
-						value={values.conditionExpression as string}
-					/>
-				)}
-			</Card>
+								parentWindow.Liferay.fire(
+									'openExpressionBuilderModal',
+									{
+										onSave: handleSave,
+										required: true,
+										source: values.conditionExpression,
+										validateExpressionURL,
+									}
+								);
+							}}
+							placeholder={Liferay.Language.get(
+								'create-an-expression'
+							)}
+							value={values.conditionExpression as string}
+						/>
+					)}
+				</Card>
+			)}
 
 			{warningAlerts.requiredFields && (
 				<ClayAlert


### PR DESCRIPTION
- LPS-170932 add new function to extract the requestId from url
- LPS-170569 Add KeywordCanDisplayInSemibold Testcase
- LPS-170554 Add CanDisplayAllAttributes Testcase
- LPS-170554 Adjusting teardown for the new tests
- LPS-170554 SF
- LPS-170569 Add ClayAlertToast path file
- LPS-170569 Adjusting the tasks of KeywordCanDisplayInSemibold Testcase
- LPS-170554 Adjusting the tasks of CanDisplayAllAttributes Testcase
- LPS-170554 SF
- LPS-170554 Add ClayAlert.path file for the static alert paths
- LPS-170569 Refactor test
- LPS-170569 Remove duplicate path
- LPS-77699 Update Translations
- LPS-171318 Allow adding an object action condition expression for some commerce triggers
- LPS-171431 Hide condition card when trigger was different from a specific condition
