### PR TITLE
LPS- Preserve folder capitalization in CMS move modal

### DIFF
--- a/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/modal/FolderItemSelectorModalContent.tsx
+++ b/modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/modal/FolderItemSelectorModalContent.tsx
@@ -274,6 +274,8 @@ function FolderItemSelectorModalContent({
 
 	const {observer, onOpenChange, open} = useModal();
 
+	const getFolderTitle = (item: any) => item.embedded?.title ?? item.title;
+
 	function handleSpaceClick(space: Space) {
 		setCurrentSpace(space);
 		setSchemaKey((prev) => prev + 1);
@@ -429,7 +431,7 @@ function FolderItemSelectorModalContent({
 									selectedItemType === 'folder'
 										? {
 												description: 'description',
-												title: 'title',
+												title: 'embedded.title',
 											}
 										: {
 												description: 'description',
@@ -446,7 +448,7 @@ function FolderItemSelectorModalContent({
 									fields: [
 										selectedItemType === 'folder'
 											? {
-													fieldName: 'title',
+													fieldName: 'embedded.title',
 													label: Liferay.Language.get(
 														'title'
 													),
@@ -479,7 +481,7 @@ function FolderItemSelectorModalContent({
 						selectedItemType === 'folder'
 							? {
 									id: 'embedded.id',
-									label: 'title',
+									label: 'embedded.title',
 									value: 'embedded.id',
 								}
 							: {
@@ -509,7 +511,7 @@ function FolderItemSelectorModalContent({
 							const item = items[0];
 							const isFolder = selectedItemType === 'folder';
 
-							let name = item.title;
+							let name = getFolderTitle(item);
 
 							if (isFolder) {
 								const isRootFolder =
@@ -518,7 +520,9 @@ function FolderItemSelectorModalContent({
 										null;
 
 								if (isRootFolder) {
-									name = currentSpace?.name || item.title;
+									name =
+										currentSpace?.name ||
+										getFolderTitle(item);
 								}
 							}
 

--- a/modules/apps/site/site-cms-site-initializer/test/js/main_view/modal/FolderItemSelectorModalContent.test.tsx
+++ b/modules/apps/site/site-cms-site-initializer/test/js/main_view/modal/FolderItemSelectorModalContent.test.tsx
@@ -1,0 +1,132 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2025 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+import '@testing-library/jest-dom';
+
+import {fireEvent, render, screen, waitFor} from '@testing-library/react';
+import React from 'react';
+
+import FolderService from '../../../../src/main/resources/META-INF/resources/js/common/services/FolderService';
+import FolderItemSelectorModalContent from '../../../../src/main/resources/META-INF/resources/js/main_view/modal/FolderItemSelectorModalContent';
+import {OBJECT_ENTRY_FOLDER_CLASS_NAME} from '../../../../src/main/resources/META-INF/resources/js/common/utils/constants';
+
+const mockOpenToast = jest.fn();
+const mockItemSelectorModal = jest.fn();
+let mockSelectedItem: any = {};
+
+jest.mock('@clayui/modal', () => ({
+	useModal: () => ({
+		observer: {},
+		onOpenChange: jest.fn(),
+		open: true,
+	}),
+}));
+
+jest.mock('@liferay/frontend-js-item-selector-web', () => ({
+	ItemSelectorModal: (props: any) => {
+		mockItemSelectorModal(props);
+
+		return (
+			<button onClick={() => props.onItemsChange([mockSelectedItem])}>
+				select-item
+			</button>
+		);
+	},
+}));
+
+jest.mock('frontend-js-components-web', () => ({
+	openToast: (props: any) => mockOpenToast(props),
+}));
+
+jest.mock('frontend-js-web', () => ({
+	sub: (message: string, ...args: string[]) => `${message} ${args.join(' ')}`,
+}));
+
+jest.mock(
+	'../../../../src/main/resources/META-INF/resources/js/common/services/FolderService',
+	() => ({
+		__esModule: true,
+		default: {
+			copyFolder: jest.fn(),
+			copyReplaceFolder: jest.fn(),
+			moveFolder: jest.fn(),
+			moveReplaceFolder: jest.fn(),
+			searchFolder: jest.fn(),
+		},
+	})
+);
+
+const DEFAULT_PROPS = {
+	action: 'move' as const,
+	assetLibraries: [
+		{externalReferenceCode: 'default', groupId: 101, name: 'Space A'},
+	],
+	itemData: {
+		actions: {},
+		embedded: {
+			id: 2001,
+			scopeId: 101,
+			title: 'Source Folder',
+		},
+		entryClassName: OBJECT_ENTRY_FOLDER_CLASS_NAME,
+		id: 2001,
+		title: 'Source Folder',
+	},
+	loadData: jest.fn(),
+	objectEntryFolderExternalReferenceCode: 'folder-erc',
+	rootObjectEntryFolderExternalReferenceCode: 'L_CONTENTS',
+};
+
+describe('FolderItemSelectorModalContent', () => {
+	beforeEach(() => {
+		jest.clearAllMocks();
+		mockSelectedItem = {};
+
+		(FolderService.searchFolder as jest.Mock).mockResolvedValue({
+			data: {items: []},
+		});
+		(FolderService.moveFolder as jest.Mock).mockResolvedValue({
+			error: null,
+		});
+	});
+
+	it('uses embedded.title for folder card/table labels and locator', () => {
+		render(<FolderItemSelectorModalContent {...DEFAULT_PROPS} />);
+
+		const props = mockItemSelectorModal.mock.calls[0][0];
+		const [cardsView, tableView] = props.fdsProps.views;
+
+		expect(cardsView.schema.title).toBe('embedded.title');
+		expect(tableView.schema.fields[0].fieldName).toBe('embedded.title');
+		expect(props.locator.label).toBe('embedded.title');
+	});
+
+	it('preserves folder capitalization from embedded.title when selecting a folder', async () => {
+		mockSelectedItem = {
+			embedded: {
+				id: 3001,
+				parentObjectEntryFolderId: 999,
+				title: 'My Mixed Case Folder',
+			},
+			title: 'my mixed case folder',
+		};
+
+		render(<FolderItemSelectorModalContent {...DEFAULT_PROPS} />);
+
+		fireEvent.click(screen.getByRole('button', {name: 'select-item'}));
+
+		await waitFor(() => {
+			expect(FolderService.moveFolder).toHaveBeenCalledWith(2001, 3001);
+		});
+
+		expect(mockOpenToast).toHaveBeenCalledWith(
+			expect.objectContaining({
+				message: expect.stringContaining(
+					'<strong>My Mixed Case Folder</strong>'
+				),
+			})
+		);
+	});
+});


### PR DESCRIPTION
### Motivation
- The CMS folder move/copy modal was displaying folder names in lowercase because it used the search `title` field instead of the embedded object display title, causing original capitalization to be lost in the UI.
- The modal should render the folder label exactly as provided by the embedded object so move/copy operations and toasts reflect the original capitalization.

### Description
- Read folder labels from `embedded.title` (instead of `title`) in the ItemSelectorModal FDS schema `cards` view, `table` view field, and `locator.label` to ensure the UI displays the embedded title.
- Introduced a small helper `getFolderTitle` and updated selection logic to use `embedded.title` (with fallback to `title`) and to preserve `currentSpace.name` for root folders when applicable; updated the selection payload to pass the preserved `title`.
- Added a Jest test `FolderItemSelectorModalContent.test.tsx` that verifies the FDS schema uses `embedded.title` and that selecting a folder preserves mixed-case capitalization through the move flow and toast message.
- Modified files: `modules/apps/site/site-cms-site-initializer/src/main/resources/META-INF/resources/js/main_view/modal/FolderItemSelectorModalContent.tsx` and added `modules/apps/site/site-cms-site-initializer/test/js/main_view/modal/FolderItemSelectorModalContent.test.tsx`.

### Testing
- Ran `npm test -- FolderItemSelectorModalContent.test.tsx --runInBand` and the suite passed (`2 passed`).
- Ran `npx prettier --check` and then `npx prettier --write` to fix formatting; `prettier --check` succeeded after formatting.
- Ran `git diff --check` (no issues reported).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bae2e2bf7883329f12e4a6228e98c7)